### PR TITLE
Feature/string deref test

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,7 +15,7 @@ This is the official `memsafe` crate, hosted at [GitHub](https://github.com/po0u
 use memsafe::MemSafe;
 let mut secret = MemSafe::new(String::from("secret")).unwrap();
 secret.push_str(" data");
-println!("Secure data: {}", secret);
+println!("Secure data: {}", *secret);
 ```
 ## Features
 - **Memory Locking**: Prevents swapping to disk using `mlock` (Unix) or `VirtualLock` (Windows).

--- a/tests/memory_tests.rs
+++ b/tests/memory_tests.rs
@@ -62,4 +62,21 @@ mod memory_safety_tests {
         secret.push_str(" data");
         assert_eq!(secret.as_str(), "secret data");
     }
+    
+    #[test]
+    fn test_string_append_and_print() {
+        let mut secret = MemSafe::new(String::from("secret")).unwrap();
+        
+        secret.push_str(" data");
+        
+        assert_eq!(*secret, "secret data");
+        
+
+        let output = format!("Secure data: {}", *secret);
+        assert_eq!(output, "Secure data: secret data");
+        
+        let length = secret.len();
+        assert_eq!(length, 11);
+        assert_eq!(*secret, "secret data");
+    }
 }


### PR DESCRIPTION
# String Dereferencing Test and README Fix

## Summary
This PR adds a new test case demonstrating proper string dereferencing when using MemSafe and fixes the README example to correctly show how to print MemSafe-wrapped strings.

## Changes
- Added `test_string_append_and_print` test case that demonstrates:
  - Creating a MemSafe-wrapped string
  - Appending to the string
  - Properly dereferencing the string for display (`*secret`)
  - Verifying memory protection/access operations
- Fixed README usage example to show proper dereferencing when printing to console

## Why
Previously, the README example showed code that would not compile due to `MemSafe<String>` not implementing the `Display` trait. This PR ensures the documentation accurately reflects the correct usage pattern, supported by a dedicated test case.

## Testing
All existing and new tests pass successfully on the local development environment.

## Additional Notes
This change is purely additive and does not modify any existing behavior. It helps users avoid confusion when following the README examples.