### PR TITLE
Make cleanup best-effort and bump to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memsafe"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A Secure cross-platform Rust library for securely wrapping data in memory"
 authors = [

--- a/README.MD
+++ b/README.MD
@@ -57,7 +57,7 @@ println!("Secure data: {:02X?}", *secret);
 ## Features
 - **Memory Locking**: Prevents swapping to disk using `mlock` (Unix) or `VirtualLock` (Windows).
 - **Access Restriction**: Defaults to no-access mode, with temporary read/write windows.
-- **Secure Cleanup**: Zeroes memory on drop.
+- **Secure Cleanup**: Zeroes memory on drop. Cleanup is best-effort: if restoring privileges, unlocking, or deallocating the protected region fails, `memsafe` logs an error to stderr instead of panicking.
 - **Cross-Platform**: Supports Unix (via `libc`) and Windows (via `winapi`) with optional dependencies.
 
 ## Installation

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -86,10 +86,21 @@ impl<T> DerefMut for Cell<T> {
 
 impl<T> Drop for Cell<T> {
     fn drop(&mut self) {
-        mem_readwrite(self.ptr, std::mem::size_of::<T>()).unwrap();
-        ptr_drop_in_place(self.ptr);
-        ptr_fill_zero(self.ptr);
-        mem_unlock(self.ptr, std::mem::size_of::<T>()).unwrap();
-        mem_dealloc(self.ptr, std::mem::size_of::<T>()).unwrap();
+        let len = std::mem::size_of::<T>();
+        // if we cannot safely obtain read-write access, avoid touching the contents
+        // but still attempt to unlock and deallocate the underlying memory region
+        match mem_readwrite(self.ptr, len) {
+            Ok(()) => {
+                ptr_drop_in_place(self.ptr);
+                ptr_fill_zero(self.ptr);
+            }
+            Err(e) => eprintln!("memsafe: drop: failed to set read-write before cleanup: {}", e),
+        }
+        if let Err(e) = mem_unlock(self.ptr, len) {
+            eprintln!("memsafe: drop: failed to unlock memory: {}", e);
+        }
+        if let Err(e) = mem_dealloc(self.ptr, len) {
+            eprintln!("memsafe: drop: failed to deallocate memory: {}", e);
+        }
     }
 }

--- a/src/mem_safe.rs
+++ b/src/mem_safe.rs
@@ -110,7 +110,9 @@ impl<T> Deref for MemSafeRead<'_, T> {
 
 impl<T> Drop for MemSafeRead<'_, T> {
     fn drop(&mut self) {
-        self.mem_safe.cell.low_priv().unwrap();
+        if let Err(e) = self.mem_safe.cell.low_priv() {
+            eprintln!("memsafe: drop: failed to restore low privileges after read: {}", e);
+        }
     }
 }
 
@@ -134,6 +136,8 @@ impl<T> DerefMut for MemSafeWrite<'_, T> {
 
 impl<T> Drop for MemSafeWrite<'_, T> {
     fn drop(&mut self) {
-        self.mem_safe.cell.low_priv().unwrap();
+        if let Err(e) = self.mem_safe.cell.low_priv() {
+            eprintln!("memsafe: drop: failed to restore low privileges after write: {}", e);
+        }
     }
 }


### PR DESCRIPTION
- Make `Drop` paths best-effort: avoid panics on cleanup failures and log errors to stderr instead.
- Ensure memory is still unlocked and deallocated even if changing access permissions fails.
- Update README to document best-effort cleanup semantics.
- Bump crate version from `0.4.0` to `0.4.1`.
- resolves https://github.com/po0uyan/memsafe/issues/32

Test Plan

- cargo test