### PR TITLE
readme fixes + fork hardening

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,13 +2,11 @@
 
 # 🔐 memsafe
 
-## One of the most hardened memory guards in the Rust ecosystem.
+### Locked, sealed, zero-on-drop memory for secrets.
 
-**Five layers of OS-level armor around every secret byte** — locked in RAM, kept out of swap
-and core dumps, sealed against reads *even from your own process*, never touching the heap,
-and provably wiped on drop.
-
-**One safe type. Zero configuration. Almost every platform Rust runs on.**
+Secrets live in a locked memory page: kept out of swap, excluded from core dumps (Linux),
+inaccessible between uses (on Unix even your own process can't read it), never on the regular
+heap, and volatile-wiped on drop. All behind one safe Rust type.
 
 [![Crates.io](https://img.shields.io/crates/v/memsafe.svg)](https://crates.io/crates/memsafe)
 [![docs.rs](https://img.shields.io/docsrs/memsafe)](https://docs.rs/memsafe)
@@ -16,14 +14,14 @@ and provably wiped on drop.
 [![Downloads](https://img.shields.io/crates/d/memsafe.svg)](https://crates.io/crates/memsafe)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-🐧 **Linux** &nbsp;·&nbsp; 🍎 **macOS** &nbsp;·&nbsp; 🪟 **Windows** &nbsp;·&nbsp; ⚙️ **any Unix**
-<br/><sub>CI-proven on **10 OS/architecture targets** — x86_64 · aarch64 · ARM · i686 · RISC-V · PowerPC</sub>
+🐧 **Linux** &nbsp;·&nbsp; 🍎 **macOS** &nbsp;·&nbsp; 🪟 **Windows** &nbsp;·&nbsp; ⚙️ **other Unixes**
+<br/><sub>CI-tested on **10 OS/architecture targets** — x86_64 · aarch64 · ARM · i686 · RISC-V · PowerPC</sub>
 
 </div>
 
 ---
 
-The password you `drop()` doesn't die: its bytes linger in freed heap blocks, get paged to swap, and show up in core dumps. `memsafe` gives it armor instead — one call runs the full protection pipeline that production secret stores build by hand:
+Dropping a `String` doesn't erase it. The bytes stay in the freed heap block, can get paged out to swap, and show up in core dumps. memsafe exists to close those paths:
 
 ```rust
 use memsafe::Secret;
@@ -39,31 +37,31 @@ mmap ──▶ mlock ──▶ MADV_DONTDUMP ──▶ write in place ──▶ 
  alloc     in RAM     core dumps¹        touches the        until *you*
                                          heap or stack      read() it
 ```
-<sub>¹ Linux. See [platform notes](#platform-specific-notes) for exactly what each OS gets — we don't claim what an OS can't deliver.</sub>
+<sub>¹ Linux only. See [platform notes](#platform-specific-notes) for what each OS actually provides.</sub>
 
-### The life of your secret
+### Compared to a plain `String`
 
-| | in a plain `String` | in a `memsafe::Secret` |
+| | plain `String` | `memsafe::Secret` |
 |---|---|---|
-| Swapped to disk under memory pressure | 😬 whenever the kernel feels like it | 🔒 never — page is `mlock`'d in RAM |
-| Visible in a core dump | 😬 yes | 🙈 excluded on Linux (`MADV_DONTDUMP`) |
-| Readable while your code isn't using it | 😬 by any stray pointer or overflow | 🚫 page is `PROT_NONE` (Unix) — even *your own process* faults on access |
-| Bytes after drop | 😬 linger on the freed heap | 🧹 volatile-zeroed + compiler-fenced — the optimizer can't skip the wipe |
-| Leaked by a stray `{:?}` in a log line | 😬 trivially | 🤐 `Secret` has no `Debug`, no `Display` |
+| Swap under memory pressure | may be paged to disk | stays in RAM — page is `mlock`'d |
+| Core dumps | included | excluded on Linux (`MADV_DONTDUMP`) |
+| While your code isn't using it | readable through any stray pointer or overflow | page is `PROT_NONE` on Unix — even your own process faults on access (`PAGE_READONLY` on Windows) |
+| Bytes after drop | linger on the freed heap | volatile-zeroed + compiler-fenced — the optimizer cannot elide the wipe |
+| A stray `{:?}` in a log line | leaks it | does not compile — `Secret` has no `Debug`, no `Display` |
 
-**Why you can trust it:** a public API with zero `unsafe` for you to write, exactly two platform-gated dependencies (`libc` on Unix, `winapi` on Windows — nothing else), a CI matrix spanning Linux (x86_64, aarch64, i686, armv7, ppc64le, riscv64), macOS (x86_64, aarch64) and Windows (x86_64, i686), constructors that hand your data back instead of losing it on failure, and an [explicit threat model](#threat-model) that says out loud what we *don't* protect against.
+A few things that may help you evaluate the crate. The public API needs no `unsafe` on your side. There are two dependencies, both platform-gated (`libc` on Unix, `winapi` on Windows). The test suite includes tests where the kernel itself verifies the page sealing: a child process reads the sealed page and must die by SIGSEGV for the test to pass. And the [threat model](#threat-model) below spells out what this crate does *not* protect against, which for a security library matters as much as what it does.
 
-**Contents** — [Quick start](#-quick-start-guard-a-secret-in-60-seconds) · [Going deeper](#-going-deeper-the-pro-path) · [What you get](#what-you-get) · [How it compares](#how-it-compares) · [Threat model](#threat-model) · [Platform notes](#platform-specific-notes) · [Under the hood](#under-the-hood) · [Roadmap](#roadmap)
+**Contents** — [Quick start](#quick-start) · [Going deeper](#going-deeper) · [What you get](#what-you-get) · [How it compares](#how-it-compares) · [Threat model](#threat-model) · [Platform notes](#platform-specific-notes) · [Under the hood](#under-the-hood) · [Roadmap](#roadmap)
 
 ---
 
-## 🚀 Quick start: guard a secret in 60 seconds
+## Quick start
 
 ```shell
 cargo add memsafe
 ```
 
-**Guard an API key, password, or token** with `Secret<N>` — pick `N` large enough for your secret; unused bytes stay zero:
+Store an API key, password, or token in a `Secret<N>`. `N` is the buffer size; pick one large enough for your secret, unused bytes stay zero:
 
 ```rust
 use memsafe::Secret;
@@ -80,7 +78,7 @@ let view = secret.read().unwrap();
 assert_eq!(&view[..10], b"my-api-key");
 ```
 
-**Already have the secret in a `String` or `Vec<u8>`?** Hand it over — the source is volatile-zeroed after the copy, so no readable trace stays behind:
+If the secret already sits in a `String` or `Vec<u8>`, hand it over. The source gets volatile-zeroed after the copy, so no readable trace stays behind:
 
 ```rust
 use memsafe::Secret;
@@ -92,7 +90,7 @@ let mut secret = Secret::<64>::from_bytes(key).unwrap();
 let mut secret: Secret<64> = String::from("my-api-key").try_into().unwrap();
 ```
 
-**Read a password without it ever touching a `String`:**
+Reading a password straight from stdin, without it ever touching a `String`:
 
 ```rust
 use memsafe::Secret;
@@ -103,7 +101,7 @@ let mut secret = Secret::<256>::new_with(|buf| {
 }).unwrap();
 ```
 
-**And if construction fails, you don't lose your data.** Every owned-input constructor returns the source alongside the error, so you can retry with a bigger buffer or clean up on your own terms:
+Construction can fail (buffer too small, `mlock` limit hit). When it does, the owned-input constructors give you the source back along with the error instead of eating it:
 
 ```rust
 use memsafe::Secret;
@@ -117,20 +115,20 @@ match Secret::<4>::try_from(too_long) {
 }
 ```
 
-That's the whole onboarding. If all you need is a secret guard, you're done — `Secret<N>` defaults to the most protective behavior on every path. Everything below is for going deeper.
+If all you need is a secret guard, that's the whole API. The rest of this document is detail.
 
 ---
 
-## 🔬 Going deeper: the pro path
+## Going deeper
 
-Two types are exported, one per job:
+The crate exports two types:
 
 | Type | Use it for |
 |------|------------|
 | **`Secret<N>`** | **Secrets.** Every constructor keeps all `N` bytes inline inside the protected page; the heap-pointer pitfall is unrepresentable. |
 | **`MemSafe<T>`** | **Non-secret protected memory.** Any `T` that wants `mlock` + `mprotect` semantics — FFI scratch buffers, guard regions, data you want fault-on-touch while idle. |
 
-### `Secret<N>` construction, precisely
+### `Secret<N>` constructors
 
 | Constructor | Input | Source returned on error | Source zeroized |
 |-------------|-------|--------------------------|-----------------|
@@ -160,7 +158,7 @@ let mut buffer = MemSafe::new([0_u8; 32]).unwrap();
 }
 ```
 
-> **Why not just use `MemSafe<String>` for a password?** A `String` keeps its bytes on the regular `malloc` heap. Wrapping it in `MemSafe` only places the 24-byte header (pointer + length + capacity) inside the protected page; the actual secret bytes still live on the unprotected heap — swappable, dump-able, and not zeroed when the allocation is freed. **`Secret<N>` exists precisely to make that misuse impossible** — it can only ever wrap `[u8; N]`, which has no indirection.
+> **Why not just use `MemSafe<String>` for a password?** Because it doesn't do what it looks like it does. A `String` keeps its bytes on the regular `malloc` heap; wrapping it in `MemSafe` only protects the 24-byte header (pointer, length, capacity). The actual secret stays on the unprotected heap: swappable, dumpable, and not zeroed when freed. This is exactly the mistake `Secret<N>` is designed to rule out, since it can only wrap `[u8; N]` and there is no indirection to get wrong.
 
 ### Type-state API — access states checked by the compiler
 
@@ -194,6 +192,7 @@ println!("Secure data: {:02X?}", *secret);
 |----------|-------------------|
 | Not paged to disk | `mlock` (Unix) / `VirtualLock` (Windows) on the backing page |
 | Not in core dumps | `madvise(MADV_DONTDUMP)` — **Linux only** |
+| Zeroed in forked children | `madvise(MADV_WIPEONFORK)` — **Linux only**; the kernel wipes the child's copy of the page |
 | Inaccessible between operations | `mprotect(PROT_NONE)` on Unix; `PAGE_READONLY` on Windows (the strictest level Windows offers in this model) |
 | Zero-on-drop | Byte-wise `write_volatile` + `compiler_fence(SeqCst)` over the page immediately before `munmap` / `VirtualFree` |
 | No allocator round-trip | Bytes are copied straight from the source into the protected page; they never reach the regular `malloc` heap |
@@ -206,7 +205,7 @@ println!("Secure data: {:02X?}", *secret);
 
 ## How it compares
 
-The Rust ecosystem has excellent secret-hygiene crates; they solve different layers of the problem. `memsafe`'s niche is **automating the full OS-level stack behind a safe, typed API**:
+There are several good crates in this space, and they solve different layers of the problem. Where memsafe fits: it automates the OS-level protections behind a typed API, instead of giving you primitives or a wrapper type alone.
 
 | Capability | [`zeroize`](https://crates.io/crates/zeroize) | [`secrecy`](https://crates.io/crates/secrecy) | [`memsec`](https://crates.io/crates/memsec) | [`region`](https://crates.io/crates/region) | `memsafe` |
 |---|---|---|---|---|---|
@@ -218,7 +217,7 @@ The Rust ecosystem has excellent secret-hygiene crates; they solve different lay
 | Safe API (no `unsafe` for the caller) | ✅ | ✅ | ❌ raw primitives | ✅ | ✅ |
 | Source returned on constructor failure | — | — | — | — | ✅ |
 
-These are complements, not competitors: `zeroize`/`secrecy` give you type-level hygiene for secrets that must live in ordinary structs, `memsec` and `region` give you raw primitives to build your own container — and `memsafe` is that container, already built, tested, and cross-platform.
+These combine well rather than compete. `zeroize` and `secrecy` are the right tools for secrets that have to live in ordinary structs. `memsec` and `region` are the right tools if you want to build your own container. memsafe is for when you want the container already built.
 
 ## Threat model
 
@@ -226,16 +225,19 @@ We list this explicitly because vague "secure" claims are how secrets get leaked
 
 **memsafe is designed to defend against:**
 
-- Secrets being written to disk via swap or hibernation (mitigated by `mlock` / `VirtualLock`).
+- Secrets being written to disk via swap (mitigated by `mlock` / `VirtualLock`).
 - Secrets appearing in a Linux core dump (mitigated by `madvise(MADV_DONTDUMP)`).
 - The Rust / system allocator handing freed-but-not-zeroed bytes to a later caller (mitigated by zero-on-drop and by never routing the secret through the global allocator).
 - Accidental reads or writes while the buffer is logically inactive (mitigated by `mprotect` / `VirtualProtect` between operations and, optionally, by the type-state API).
 - The "owned bytes" case: the secret being silently left on the regular heap after the source is dropped (mitigated by `Secret::from_bytes`'s explicit volatile zeroization of the source slice before drop).
 - The "wrong wrapper" case: a developer wrapping a `String` or `Vec<u8>` in `MemSafe` and unknowingly leaving the payload on the unprotected heap (mitigated structurally by `Secret<N>` — by construction it can only wrap `[u8; N]`, where the secret lives inline).
+- A forked child inheriting a copy of the secret — **Linux only**, via `madvise(MADV_WIPEONFORK)`: the kernel replaces the child's view of the page with zeros. On other Unixes the child still receives an unlocked copy-on-write copy; see below.
 
 **memsafe does NOT defend against:**
 
 - A process running with privilege equivalent to or greater than your own — for example, a debugger attached via `ptrace`, or root on the same machine. OS protection ends at the process boundary.
+- **Hibernation (suspend-to-disk).** The hibernation image contains all of physical RAM, *including* `mlock`'d pages — `mlock` prevents swapping, not hibernation. If laptops are in your threat model, pair this crate with encrypted swap/hibernation or full-disk encryption.
+- **`fork()` inheritance on non-Linux Unixes.** Outside Linux, a forked child receives a copy-on-write copy of the secret page *without* the `mlock` — an unlocked, swappable copy in a process that may not know it holds one. (On Linux the page is kernel-zeroed in the child via `MADV_WIPEONFORK`.) On macOS and the BSDs, avoid fork-based worker models while secrets are live, or construct secrets after forking.
 - Side-channel attacks (cache timing, Spectre/Meltdown-class speculation, power analysis, etc.).
 - Bytes left behind in CPU registers, vector lanes, or temporary spill slots after a `copy_from_slice`. The protection is at the memory-page level, not the microarchitectural level.
 - Hardware attackers with physical bus access, cold-boot capability, or DMA to the host.
@@ -255,13 +257,13 @@ If your threat model includes any of the items in the second list, `memsafe` is 
 
 The implementation behind each guarantee, for readers who want the details:
 
-- **Allocation and locking.** Each instance allocates one or more pages via `mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)` on Unix or `VirtualAlloc(NULL, len, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE)` on Windows. The page is then pinned with `mlock` / `VirtualLock` so the kernel cannot page it out to swap or include it in a hibernation file. On Linux, `madvise(MADV_DONTDUMP)` additionally tells the kernel to omit the page from any core dump produced for the process.
+- **Allocation and locking.** Each instance allocates one or more pages via `mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)` on Unix or `VirtualAlloc(NULL, len, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE)` on Windows. The page is then pinned with `mlock` / `VirtualLock` so the kernel cannot page it out to swap. (Note: `mlock` does **not** exclude the page from a hibernation image — see the threat model.) On Linux, `madvise(MADV_DONTDUMP)` additionally tells the kernel to omit the page from any core dump produced for the process.
 
 - **Access transitions.** All access to the backing page goes through the internal `Cell` abstraction, which calls `mprotect` (Unix) or `VirtualProtect` (Windows) to elevate the page for the duration of a read or write. As soon as the temporary access guard is dropped, the page is restored to its lowest-privilege state (`PROT_NONE` on Unix, `PAGE_READONLY` on Windows). The `type-state` feature lifts this state machine into the type system.
 
 - **In-place initialization avoids a stack copy.** `Secret::<N>::new_with(|buf| ...)` allocates the protected page first, then hands the closure a `&mut [u8; N]` that points *inside* the locked region. The secret bytes are written directly into protected memory; they never live in a stack-allocated `[u8; N]` that the compiler would otherwise leave behind in the calling frame.
 
-- **Panic-safe construction.** Construction is guarded by an internal RAII rollback guard: if any setup step fails, or a caller-provided `new_with` closure panics after writing partial secret bytes, unwinding volatile-zeroes the page, unlocks it, and unmaps it before the error or panic propagates. A partially-built secret can neither leak nor linger.
+- **Panic-safe construction.** Construction is guarded by an internal RAII rollback guard: if any setup step fails, or a caller-provided `new_with` closure panics after writing partial secret bytes, unwinding volatile-zeroes the page, unlocks it, and unmaps it before the error or panic propagates.
 
 - **Source zeroization for `Secret::from_bytes`.** After copying the source bytes into the protected page, `from_bytes` walks the source slice (everything `AsMut::as_mut` exposes) and overwrites every byte with `ptr::write_volatile(0)`, followed by a `compiler_fence(Ordering::SeqCst)`. Volatile stores are guaranteed side effects the compiler may not elide, and the fence prevents the wipe from being reordered past later code. On a memory-protection error the zeroization has already run; on a length-mismatch error the source is returned untouched so the caller can decide what to do with it.
 
@@ -273,6 +275,7 @@ The implementation behind each guarantee, for readers who want the details:
 
 Planned hardening work, roughly in priority order:
 
+- **`fork()` hygiene beyond Linux.** Linux already gets `madvise(MADV_WIPEONFORK)`; add `minherit(INHERIT_ZERO)` on the BSDs where available.
 - **Closure-based access API.** Replace `read()` / `write()` guards with `read(|r| ...)` / `write(|w| ...)` closures, so the page is provably returned to its lowest-privilege state when the closure returns.
 - **Guard pages.** Allocate adjacent inaccessible pages around the protected region to turn over- and under-runs into immediate faults.
 - **Windows core-dump exclusion.** Mark protected pages so they are omitted from minidumps.

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -135,11 +135,12 @@ impl<T> Cell<T> {
         mem_wipe_on_fork(ptr, len)?;
 
         // Copy `value`'s bytes into the protected page, wipe the original
-        // through the same borrow, and only then `forget` it. The copy never
-        // passes through another function's stack frame, and the wipe writes
-        // through a pointer whose referent is still live at that point.
-        // Mark the guard `Written` between the copy and the wipe so a
-        // (hypothetical) panic in the wipe still triggers full cleanup.
+        // through the same borrow, then `forget` it. Ordering constraints:
+        // the bytes must not move through another function's stack frame
+        // (a copy there could never be wiped), the wipe must happen while
+        // `value` is still live, and `forget` must come last so the wiped
+        // value is never dropped. `Written` is marked between copy and
+        // wipe so a panic in between still wipes the page on rollback.
         let val_ptr = &mut value as *mut T;
         unsafe {
             std::ptr::copy_nonoverlapping(val_ptr as *const u8, ptr as *mut u8, len);

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -4,11 +4,11 @@ use std::ops::{Deref, DerefMut};
 use crate::ffi::mem_noaccess;
 
 #[cfg(target_os = "linux")]
-use crate::ffi::mem_no_dump;
+use crate::ffi::{mem_no_dump, mem_wipe_on_fork};
 
 use crate::{
     ffi::{mem_alloc, mem_dealloc, mem_lock, mem_readonly, mem_readwrite, mem_unlock},
-    ptr_ops::{ptr_deref, ptr_deref_mut, ptr_drop_in_place, ptr_fill_zero, ptr_write, secure_zero},
+    ptr_ops::{ptr_deref, ptr_deref_mut, ptr_drop_in_place, ptr_fill_zero, secure_zero},
     MemoryError,
 };
 
@@ -96,7 +96,7 @@ impl<T> Drop for PartialCell<T> {
         if self.state == PartialState::Written {
             let _ = mem_readwrite(self.ptr, self.len);
             // `*self.ptr` holds a valid `T` written by `Cell::new`'s
-            // `ptr_write` or `Cell::new_with`'s `init` closure. The page
+            // byte copy or `Cell::new_with`'s `init` closure. The page
             // is RW (or has just been re-set RW above).
             ptr_drop_in_place(self.ptr);
             ptr_fill_zero(self.ptr);
@@ -115,6 +115,12 @@ impl<T> Drop for PartialCell<T> {
 impl<T> Cell<T> {
     pub fn new(mut value: T) -> Result<Cell<T>, MemoryError> {
         let len = std::mem::size_of::<T>();
+        if len == 0 {
+            return Err(MemoryError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "zero-sized values cannot be placed in protected memory",
+            )));
+        }
         let ptr = mem_alloc(len)?;
         // From here on the page is owned by `guard`. Any `?` failure or
         // panic will roll back through `PartialCell::drop`.
@@ -125,16 +131,22 @@ impl<T> Cell<T> {
 
         #[cfg(target_os = "linux")]
         mem_no_dump(ptr, len)?;
+        #[cfg(target_os = "linux")]
+        mem_wipe_on_fork(ptr, len)?;
 
-        // Move `value` into the protected page, then wipe the caller's
-        // stack slot. `ptr_write` is a bitwise copy + `forget(src)`; the
-        // bytes at the original stack location persist until we zero them.
-        // Mark the guard `Written` between the move and the stack-wipe so
-        // a (hypothetical) panic in the wipe still triggers full cleanup.
+        // Copy `value`'s bytes into the protected page, wipe the original
+        // through the same borrow, and only then `forget` it. The copy never
+        // passes through another function's stack frame, and the wipe writes
+        // through a pointer whose referent is still live at that point.
+        // Mark the guard `Written` between the copy and the wipe so a
+        // (hypothetical) panic in the wipe still triggers full cleanup.
         let val_ptr = &mut value as *mut T;
-        ptr_write(ptr, value);
+        unsafe {
+            std::ptr::copy_nonoverlapping(val_ptr as *const u8, ptr as *mut u8, len);
+        }
         guard.mark_written();
         ptr_fill_zero(val_ptr);
+        std::mem::forget(value);
 
         #[cfg(windows)]
         mem_readonly(ptr, len)?;
@@ -190,6 +202,12 @@ impl<const N: usize> Cell<[u8; N]> {
         F: FnOnce(&mut [u8; N]),
     {
         let len = std::mem::size_of::<[u8; N]>();
+        if len == 0 {
+            return Err(MemoryError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "zero-sized values cannot be placed in protected memory",
+            )));
+        }
         let ptr: *mut [u8; N] = mem_alloc(len)?;
         // From here on the page is owned by `guard`. Any `?` failure, or
         // a panic from `init`, will roll back through `PartialCell::drop`.
@@ -200,6 +218,8 @@ impl<const N: usize> Cell<[u8; N]> {
 
         #[cfg(target_os = "linux")]
         mem_no_dump(ptr, len)?;
+        #[cfg(target_os = "linux")]
+        mem_wipe_on_fork(ptr, len)?;
 
         // Mark `Written` *before* invoking `init`: the closure may write
         // partial secret bytes and then panic. `[u8; N]` has trivial
@@ -262,10 +282,18 @@ impl<T> DerefMut for Cell<T> {
 
 impl<T> Drop for Cell<T> {
     fn drop(&mut self) {
-        mem_readwrite(self.ptr, std::mem::size_of::<T>()).unwrap();
+        let len = std::mem::size_of::<T>();
+        // Fail secure: if the page can't be made writable it can't be wiped,
+        // so leak it — still mapped, locked, and sealed — rather than return
+        // a dirty page to the OS for reuse by the next allocation. This also
+        // keeps drop from panicking, which would abort the process when a
+        // panic is already unwinding.
+        if mem_readwrite(self.ptr, len).is_err() {
+            return;
+        }
         ptr_drop_in_place(self.ptr);
         ptr_fill_zero(self.ptr);
-        mem_unlock(self.ptr, std::mem::size_of::<T>()).unwrap();
-        mem_dealloc(self.ptr, std::mem::size_of::<T>()).unwrap();
+        let _ = mem_unlock(self.ptr, len);
+        let _ = mem_dealloc(self.ptr, len);
     }
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -288,3 +288,14 @@ pub fn mem_unlock<T>(ptr: *mut T, len: usize) -> Result<(), MemoryError> {
 pub fn mem_no_dump<T>(ptr: *mut T, len: usize) -> Result<(), MemoryError> {
     unix::madvice(ptr as *mut c_void, len, MADV_DONTDUMP)
 }
+
+/// Tells the kernel to zero this memory range in any forked child.
+///
+/// Without this, `fork()` gives the child a copy-on-write copy of the secret
+/// page *without* the `mlock` — an unlocked, swappable copy in a process that
+/// may not know it holds one. `MADV_WIPEONFORK` (Linux 4.14+) makes the
+/// kernel replace the child's view of the range with zero-filled pages.
+#[cfg(target_os = "linux")]
+pub fn mem_wipe_on_fork<T>(ptr: *mut T, len: usize) -> Result<(), MemoryError> {
+    unix::madvice(ptr as *mut c_void, len, libc::MADV_WIPEONFORK)
+}

--- a/src/ptr_ops.rs
+++ b/src/ptr_ops.rs
@@ -1,9 +1,5 @@
 use std::sync::atomic::{compiler_fence, Ordering};
 
-pub fn ptr_write<T>(ptr: *mut T, val: T) {
-    unsafe { ptr.write(val) };
-}
-
 /// Volatile, compiler-fenced zeroization of `*ptr`.
 ///
 /// Writes `size_of::<T>()` zero bytes through `ptr` using `write_volatile`,

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -94,7 +94,10 @@ impl<const N: usize> Secret<N> {
     /// Only the bytes exposed by [`AsMut::as_mut`] are zeroized. For containers
     /// like `Vec` or `String`, capacity beyond `len` is not visited; call
     /// [`Vec::shrink_to_fit`] / [`String::shrink_to_fit`] beforehand if that
-    /// matters for your threat model.
+    /// matters for your threat model. Likewise, if the container ever *grew*
+    /// while holding secret bytes, earlier reallocations left copies on the
+    /// heap that this crate cannot reach — build the secret at its final size,
+    /// or better, write it directly into protected memory with [`Secret::new_with`].
     pub fn from_bytes<T: AsMut<[u8]>>(bytes: T) -> Result<Self, (T, MemoryError)> {
         Cell::<[u8; N]>::from_bytes(bytes).map(|cell| Secret {
             inner: MemSafe { cell },
@@ -104,6 +107,11 @@ impl<const N: usize> Secret<N> {
     /// Obtain temporary read access to the secret bytes. The returned guard
     /// derefs to `&[u8; N]` and restores lowest-privilege access on drop
     /// (Unix).
+    ///
+    /// **Timing note:** comparing secret bytes with `==` is not
+    /// constant-time and can leak information through timing side channels.
+    /// If you compare secrets (password checks, MAC verification), use a
+    /// constant-time comparison such as the `subtle` crate's `ct_eq`.
     pub fn read(&mut self) -> Result<MemSafeRead<'_, [u8; N]>, MemoryError> {
         self.inner.read()
     }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -73,8 +73,8 @@ impl<const N: usize> Secret<N> {
     /// which the bytes existed in unprotected memory.
     ///
     /// If `init` panics, the construction guard volatile-zeroes the page,
-    /// unlocks it, and unmaps it before the panic propagates — a partially
-    /// written secret can neither leak nor linger.
+    /// unlocks it, and unmaps it before the panic propagates; no partially
+    /// written secret remains in memory.
     pub fn new_with<F>(init: F) -> Result<Self, MemoryError>
     where
         F: FnOnce(&mut [u8; N]),
@@ -91,13 +91,14 @@ impl<const N: usize> Secret<N> {
     /// - On length mismatch (`source.len() > N`): source is returned untouched.
     /// - On memory-protection failure: source has already been zeroed.
     ///
-    /// Only the bytes exposed by [`AsMut::as_mut`] are zeroized. For containers
-    /// like `Vec` or `String`, capacity beyond `len` is not visited; call
-    /// [`Vec::shrink_to_fit`] / [`String::shrink_to_fit`] beforehand if that
-    /// matters for your threat model. Likewise, if the container ever *grew*
-    /// while holding secret bytes, earlier reallocations left copies on the
-    /// heap that this crate cannot reach — build the secret at its final size,
-    /// or better, write it directly into protected memory with [`Secret::new_with`].
+    /// Only the bytes exposed by [`AsMut::as_mut`] are zeroized; unused
+    /// capacity in a `Vec` or `String` is not visited. Call `shrink_to_fit`
+    /// first if trailing capacity may hold earlier secret content. The same
+    /// limitation applies to reallocation: a container that grew while
+    /// holding secret bytes freed its previous allocations unwiped, and
+    /// those copies are beyond this crate's reach. [`Secret::new_with`]
+    /// avoids both issues by never holding the secret in a growable
+    /// container.
     pub fn from_bytes<T: AsMut<[u8]>>(bytes: T) -> Result<Self, (T, MemoryError)> {
         Cell::<[u8; N]>::from_bytes(bytes).map(|cell| Secret {
             inner: MemSafe { cell },

--- a/src/type_state.rs
+++ b/src/type_state.rs
@@ -1,3 +1,20 @@
+//! Compile-time enforced access states for protected memory.
+//!
+//! # Warning: heap-backed types are not protected
+//!
+//! This module's `MemSafe<T>` accepts any `T`, including `String` and
+//! `Vec<u8>`. For those types only the small header (pointer, length,
+//! capacity) lands in the protected page — the actual contents stay on the
+//! regular heap: swappable, dumpable, and not zeroed on free. Operations
+//! that grow the container (`push_str`, `push`, …) reallocate on the
+//! unprotected heap, and `Deref` makes it easy to `clone()` an unprotected
+//! copy out without noticing.
+//!
+//! **For secrets, use [`crate::Secret`], which stores every byte inline.**
+//! Use this module for non-secret data that benefits from `mlock` +
+//! `mprotect` semantics, with inline types (`[u8; N]`, integers, plain
+//! structs without heap pointers).
+
 use std::{
     convert::Infallible,
     marker::PhantomData,

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -205,3 +205,75 @@ fn mlock_failure_rolls_back_cleanly() {
         "locking 4 TiB must fail with a MemoryError"
     );
 }
+
+/// True when the tests run under a user-mode emulator (the cross/qemu CI
+/// targets), where fork+madvise semantics don't match a real kernel.
+#[cfg(target_os = "linux")]
+fn emulated_kernel() -> bool {
+    std::env::vars().any(|(k, _)| {
+        k == "QEMU_LD_PREFIX"
+            || k == "CROSS_RUNNER"
+            || (k.starts_with("CARGO_TARGET_") && k.ends_with("_RUNNER"))
+    })
+}
+
+/// `MADV_WIPEONFORK` enforcement: a forked child must see a zeroed page, not
+/// a copy of the secret. Without it, fork() hands the child an *unlocked*
+/// copy-on-write copy of the secret that can be swapped or dumped.
+///
+/// The parent holds a read guard across the fork so the page is readable in
+/// both processes; the child inspects its copy and reports through its exit
+/// code. The child only calls async-signal-safe things (volatile reads,
+/// `_exit`) because forking a threaded test runner allows nothing more.
+#[cfg(target_os = "linux")]
+#[test]
+fn forked_child_sees_wiped_secret() {
+    if emulated_kernel() {
+        eprintln!("skipping: qemu user-mode emulation does not reproduce fork/madvise semantics");
+        return;
+    }
+
+    let mut secret = Secret::<32>::new_with(|buf| buf.fill(0xAB)).unwrap();
+    let view = secret.read().unwrap(); // page readable across the fork
+    let ptr = view.as_ptr();
+
+    match unsafe { libc::fork() } {
+        0 => {
+            // Child: every byte must be zero. Exit 0 on success, 42 if any
+            // secret byte survived the fork.
+            for i in 0..32 {
+                if unsafe { std::ptr::read_volatile(ptr.add(i)) } != 0 {
+                    unsafe { libc::_exit(42) };
+                }
+            }
+            unsafe { libc::_exit(0) };
+        }
+        pid if pid > 0 => {
+            let mut status = 0;
+            let waited = unsafe { libc::waitpid(pid, &mut status, 0) };
+            assert_eq!(waited, pid, "waitpid failed");
+            assert!(
+                libc::WIFEXITED(status),
+                "child did not exit normally: {status}"
+            );
+            assert_eq!(
+                libc::WEXITSTATUS(status),
+                0,
+                "forked child must see a kernel-zeroed page, not the secret"
+            );
+            // Parent's own copy is untouched.
+            drop(view);
+            assert_eq!(secret.read().unwrap()[0], 0xAB);
+        }
+        _ => panic!("fork failed"),
+    }
+}
+
+/// Zero-sized secrets are rejected up front with a clear error instead of a
+/// raw EINVAL surfacing from mmap.
+#[test]
+fn zero_sized_secret_is_rejected() {
+    let result = Secret::<0>::new_with(|_| {});
+    let err = result.err().expect("Secret::<0> must be rejected");
+    assert_eq!(err.inner().kind(), std::io::ErrorKind::InvalidInput);
+}


### PR DESCRIPTION
Readme cleanup plus a round of hardening.

**Readme**
- Tightened the wording throughout and made the protection claims more precise:
  - `mlock` keeps pages out of swap; hibernation images are a separate mechanism and are now listed in the threat model with a note about encrypted swap.
  - the PROT_NONE sealing is unix; windows' floor is PAGE_READONLY. Reworded the places that implied otherwise.

**Hardening**
- set MADV_WIPEONFORK on linux. Without it a forked child gets an unlocked copy-on-write copy of the secret page that can be swapped or dumped. There's a test that forks for real and the child checks its copy is zeroed.
- Cell's drop doesn't unwrap anymore. If the page can't be made writable it can't be wiped, so we leak it (still mapped, locked and sealed) instead of returning a dirty page to the OS or aborting mid-unwind.
- Cell::new used to move the value through a helper fn, which leaves a copy in that frame's stack we can't wipe. Now it copies the bytes in place and wipes the source through the live borrow.
- zero-sized values are rejected with a proper error instead of a raw EINVAL from mmap.
- doc notes for the type_state String pitfall (only the header gets protected), non-constant-time comparisons, and vec regrowth leaving old buffers behind.

Patch label, so merging cuts a release and updates the readme on crates.io too.