### PR TITLE
kernel-verified security tests, perf suite, readme performance section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,10 @@ libc = { version = "0.2" }
 winapi = { version = "0.3", features = ["memoryapi", "winnt"] }
 
 [dependencies]
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "memsafe_bench"
+harness = false

--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,7 @@ mmap ──▶ mlock ──▶ MADV_DONTDUMP ──▶ write in place ──▶ 
 
 A few things that may help you evaluate the crate. The public API needs no `unsafe` on your side. There are two dependencies, both platform-gated (`libc` on Unix, `winapi` on Windows). The test suite includes tests where the kernel itself verifies the page sealing: a child process reads the sealed page and must die by SIGSEGV for the test to pass. And the [threat model](#threat-model) below spells out what this crate does *not* protect against, which for a security library matters as much as what it does.
 
-**Contents** — [Quick start](#quick-start) · [Going deeper](#going-deeper) · [What you get](#what-you-get) · [How it compares](#how-it-compares) · [Threat model](#threat-model) · [Platform notes](#platform-specific-notes) · [Under the hood](#under-the-hood) · [Roadmap](#roadmap)
+**Contents** — [Quick start](#quick-start) · [Going deeper](#going-deeper) · [What you get](#what-you-get) · [How it compares](#how-it-compares) · [Performance](#performance) · [Threat model](#threat-model) · [Platform notes](#platform-specific-notes) · [Under the hood](#under-the-hood) · [Roadmap](#roadmap)
 
 ---
 
@@ -218,6 +218,27 @@ There are several good crates in this space, and they solve different layers of 
 | Source returned on constructor failure | — | — | — | — | ✅ |
 
 These combine well rather than compete. `zeroize` and `secrecy` are the right tools for secrets that have to live in ordinary structs. `memsec` and `region` are the right tools if you want to build your own container. memsafe is for when you want the container already built.
+
+## Performance
+
+Protection isn't free, and it's better to know the cost up front than to discover it in a profile. Construction does about five syscalls (`mmap`, `mlock`, `madvise` twice on Linux, `mprotect`), and every guard cycle is two `mprotect` calls. Measured with the criterion benches in [`benches/`](benches/memsafe_bench.rs) on an Apple Silicon macOS machine, release build:
+
+| Operation | with memsafe | plain heap (`Vec<u8>`) |
+|---|---|---|
+| Create + drop a 64 B secret | ~2.8 µs | ~9.5 ns |
+| Create + drop a 4 KiB secret | ~3.8 µs | — |
+| Ingest an owned `Vec` (`from_bytes`, 64 B) | ~2.9 µs | — |
+| Read access (unseal, read, reseal) | ~1.1 µs | ~0.35 ns |
+| Write access (unseal, write, reseal) | ~1.1 µs | — |
+
+So a protected secret costs roughly 300× a plain allocation to create, and each access costs about a microsecond. Two things follow from that:
+
+- **For credentials, keys, and tokens this is noise.** An API key read a few times per process lifetime costs single-digit microseconds in total.
+- **Don't put a per-request hot loop behind a guard cycle.** If you need the secret thousands of times per second, take one guard and do the batch inside it (the page stays readable for exactly that scope), rather than opening and dropping a guard per operation.
+
+Also note the memory cost: each secret occupies at least one OS page (typically 4 KiB) and counts against the locked-memory limit (`RLIMIT_MEMLOCK`), so size is effectively free up to a page but the number of live secrets is not unbounded.
+
+Absolute numbers are dominated by syscall cost and will differ on your OS and hardware — `cargo bench` reproduces the table for your machine.
 
 ## Threat model
 

--- a/benches/memsafe_bench.rs
+++ b/benches/memsafe_bench.rs
@@ -1,0 +1,59 @@
+//! Criterion benchmarks. Run with `cargo bench`.
+//!
+//! Every memsafe operation costs syscalls by design (mmap/mlock/madvise on
+//! construction, two mprotect per guard cycle), so the interesting numbers
+//! are the per-operation overhead and how it compares to an unprotected
+//! heap buffer. The `baseline_*` benches exist for that comparison.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use memsafe::Secret;
+
+fn construction(c: &mut Criterion) {
+    let mut g = c.benchmark_group("construction");
+    g.bench_function("secret_new_with_64B", |b| {
+        b.iter(|| Secret::<64>::new_with(|buf| buf[..10].copy_from_slice(b"my-api-key")).unwrap())
+    });
+    g.bench_function("secret_new_with_4KiB", |b| {
+        b.iter(|| Secret::<4096>::new_with(|buf| buf.fill(0xAB)).unwrap())
+    });
+    g.bench_function("secret_from_bytes_64B", |b| {
+        b.iter(|| Secret::<64>::from_bytes(black_box(b"my-api-key".to_vec())).unwrap())
+    });
+    // Unprotected equivalent, for scale: how much does the protection cost?
+    g.bench_function("baseline_vec_64B", |b| {
+        b.iter(|| {
+            let mut v = vec![0u8; 64];
+            v[..10].copy_from_slice(black_box(b"my-api-key"));
+            v
+        })
+    });
+    g.finish();
+}
+
+fn access(c: &mut Criterion) {
+    let mut g = c.benchmark_group("access");
+
+    let mut secret = Secret::<64>::new_with(|b| b.fill(7)).unwrap();
+    g.bench_function("read_guard_cycle", |b| {
+        b.iter(|| {
+            let view = secret.read().unwrap();
+            black_box(view[0])
+        })
+    });
+
+    let mut secret_w = Secret::<64>::new_with(|_| {}).unwrap();
+    g.bench_function("write_guard_cycle", |b| {
+        b.iter(|| {
+            let mut w = secret_w.write().unwrap();
+            w[0] = black_box(1);
+        })
+    });
+
+    // Unprotected equivalent, for scale.
+    let plain = [7u8; 64];
+    g.bench_function("baseline_vec_read", |b| b.iter(|| black_box(plain[0])));
+    g.finish();
+}
+
+criterion_group!(benches, construction, access);
+criterion_main!(benches);

--- a/tests/performance.rs
+++ b/tests/performance.rs
@@ -1,0 +1,112 @@
+//! Performance smoke tests.
+//!
+//! These are not benchmarks — `benches/` has criterion for real numbers.
+//! The bounds here are set an order of magnitude above what commodity
+//! hardware does, so they stay quiet through normal variance and only fail
+//! on pathological regressions: an accidental allocation per read, a leaked
+//! page per construction, a syscall storm.
+
+use memsafe::Secret;
+use std::time::Instant;
+
+/// True under the cross/qemu CI targets, where syscall overhead is not
+/// representative of any real deployment.
+fn emulated_kernel() -> bool {
+    std::env::vars().any(|(k, _)| {
+        k == "QEMU_LD_PREFIX"
+            || k == "CROSS_RUNNER"
+            || (k.starts_with("CARGO_TARGET_") && k.ends_with("_RUNNER"))
+    })
+}
+
+#[test]
+fn construction_throughput_smoke() {
+    const OPS: u32 = 500;
+    let start = Instant::now();
+    for _ in 0..OPS {
+        let secret = Secret::<256>::new_with(|b| b[..5].copy_from_slice(b"perf!")).unwrap();
+        drop(secret);
+    }
+    let elapsed = start.elapsed();
+    eprintln!(
+        "construction: {OPS} create+drop cycles in {elapsed:?} ({:?}/op)",
+        elapsed / OPS
+    );
+    if emulated_kernel() {
+        return;
+    }
+    // Typical: well under 50ms total. Budget: 15s.
+    assert!(
+        elapsed.as_secs() < 15,
+        "construction throughput collapsed: {OPS} ops took {elapsed:?}"
+    );
+}
+
+#[test]
+fn read_guard_cycle_smoke() {
+    const OPS: u32 = 10_000;
+    let mut secret = Secret::<64>::new_with(|b| b.fill(7)).unwrap();
+    let start = Instant::now();
+    for _ in 0..OPS {
+        let view = secret.read().unwrap();
+        assert_eq!(view[0], 7);
+    }
+    let elapsed = start.elapsed();
+    eprintln!(
+        "read guard: {OPS} unseal+read+reseal cycles in {elapsed:?} ({:?}/op)",
+        elapsed / OPS
+    );
+    if emulated_kernel() {
+        return;
+    }
+    // Two mprotect calls per cycle; typically tens of ms total. Budget: 15s.
+    assert!(
+        elapsed.as_secs() < 15,
+        "read-guard cycle collapsed: {OPS} ops took {elapsed:?}"
+    );
+}
+
+#[test]
+fn write_guard_cycle_smoke() {
+    const OPS: u32 = 10_000;
+    let mut secret = Secret::<64>::new_with(|_| {}).unwrap();
+    let start = Instant::now();
+    for i in 0..OPS {
+        let mut w = secret.write().unwrap();
+        w[0] = i as u8;
+    }
+    let elapsed = start.elapsed();
+    eprintln!(
+        "write guard: {OPS} unseal+write+reseal cycles in {elapsed:?} ({:?}/op)",
+        elapsed / OPS
+    );
+    if emulated_kernel() {
+        return;
+    }
+    assert!(
+        elapsed.as_secs() < 15,
+        "write-guard cycle collapsed: {OPS} ops took {elapsed:?}"
+    );
+}
+
+#[test]
+fn from_bytes_throughput_smoke() {
+    const OPS: u32 = 500;
+    let start = Instant::now();
+    for _ in 0..OPS {
+        let secret = Secret::<64>::from_bytes(b"0123456789abcdef".to_vec()).unwrap();
+        drop(secret);
+    }
+    let elapsed = start.elapsed();
+    eprintln!(
+        "from_bytes: {OPS} ingest+drop cycles in {elapsed:?} ({:?}/op)",
+        elapsed / OPS
+    );
+    if emulated_kernel() {
+        return;
+    }
+    assert!(
+        elapsed.as_secs() < 15,
+        "from_bytes throughput collapsed: {OPS} ops took {elapsed:?}"
+    );
+}

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -277,3 +277,164 @@ fn zero_sized_secret_is_rejected() {
     let err = result.err().expect("Secret::<0> must be rejected");
     assert_eq!(err.inner().kind(), std::io::ErrorKind::InvalidInput);
 }
+
+/// Ask the kernel, not the crate: /proc/self/smaps reports per-mapping
+/// VmFlags, so we can verify the secret's page really carries the
+/// protections we claim to configure — `lo` (mlocked), `dd` (excluded from
+/// core dumps), `wf` (wiped on fork). If a refactor ever drops one of the
+/// madvise/mlock calls, this fails even though every functional test passes.
+#[cfg(target_os = "linux")]
+#[test]
+fn kernel_reports_locked_nodump_wipeonfork_flags() {
+    if emulated_kernel() {
+        eprintln!("skipping: /proc maps under qemu describe the emulator, not the guest");
+        return;
+    }
+
+    let mut secret = Secret::<32>::new_with(|b| b.fill(1)).unwrap();
+    let view = secret.read().unwrap();
+    let addr = view.as_ptr() as usize;
+
+    let smaps = std::fs::read_to_string("/proc/self/smaps").unwrap();
+    let flags = vm_flags_for(&smaps, addr).expect("secret page not found in smaps");
+
+    for (flag, meaning) in [
+        ("lo", "mlock (never swapped)"),
+        ("dd", "MADV_DONTDUMP (excluded from core dumps)"),
+        ("wf", "MADV_WIPEONFORK (zeroed in forked children)"),
+    ] {
+        assert!(
+            flags.contains(&flag.to_string()),
+            "kernel does not report `{flag}` ({meaning}) on the secret page; VmFlags = {flags:?}"
+        );
+    }
+}
+
+/// Watch the guard state machine through the kernel's eyes: the mapping's
+/// permission bits in /proc/self/maps must read `---p` while sealed, `r--p`
+/// under a read guard, `rw-p` under a write guard, and return to `---p`
+/// after every guard drops.
+#[cfg(target_os = "linux")]
+#[test]
+fn kernel_reports_permission_transitions() {
+    if emulated_kernel() {
+        eprintln!("skipping: /proc maps under qemu describe the emulator, not the guest");
+        return;
+    }
+
+    let mut secret = Secret::<32>::new_with(|b| b.fill(1)).unwrap();
+
+    let addr = {
+        let view = secret.read().unwrap();
+        let addr = view.as_ptr() as usize;
+        assert_eq!(perms_for(addr).as_deref(), Some("r--p"), "read guard open");
+        addr
+    };
+    assert_eq!(
+        perms_for(addr).as_deref(),
+        Some("---p"),
+        "after read guard drop"
+    );
+
+    {
+        let _w = secret.write().unwrap();
+        assert_eq!(perms_for(addr).as_deref(), Some("rw-p"), "write guard open");
+    }
+    assert_eq!(
+        perms_for(addr).as_deref(),
+        Some("---p"),
+        "after write guard drop"
+    );
+
+    // Opening a guard on one secret must not unseal another.
+    let mut other = Secret::<32>::new_with(|b| b.fill(2)).unwrap();
+    let other_addr = {
+        let v = other.read().unwrap();
+        v.as_ptr() as usize
+    };
+    let _view = secret.read().unwrap();
+    assert_eq!(
+        perms_for(other_addr).as_deref(),
+        Some("---p"),
+        "unrelated secret must stay sealed while another is read"
+    );
+}
+
+/// Concurrency stress: many threads creating, writing, reading, and dropping
+/// their own secrets at once. Every thread must always observe exactly its
+/// own bytes — no cross-page interference, no protection-state races.
+#[test]
+fn concurrent_secrets_never_interfere() {
+    let handles: Vec<_> = (0u8..8)
+        .map(|t| {
+            std::thread::spawn(move || {
+                for round in 0u8..50 {
+                    let marker = t.wrapping_mul(31).wrapping_add(round);
+                    let mut secret = Secret::<128>::new_with(|b| b.fill(marker)).unwrap();
+                    {
+                        let v = secret.read().unwrap();
+                        assert!(v.iter().all(|&b| b == marker), "thread {t} round {round}");
+                    }
+                    {
+                        let mut w = secret.write().unwrap();
+                        w.fill(marker.wrapping_add(1));
+                    }
+                    let v = secret.read().unwrap();
+                    assert!(v.iter().all(|&b| b == marker.wrapping_add(1)));
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+}
+
+/// Find the VmFlags line of the smaps block covering `addr`.
+#[cfg(target_os = "linux")]
+fn vm_flags_for(smaps: &str, addr: usize) -> Option<Vec<String>> {
+    let mut in_target_block = false;
+    for line in smaps.lines() {
+        if let Some((range, _)) = line.split_once(' ') {
+            if let Some((start, end)) = range.split_once('-') {
+                if let (Ok(s), Ok(e)) = (
+                    usize::from_str_radix(start, 16),
+                    usize::from_str_radix(end, 16),
+                ) {
+                    in_target_block = s <= addr && addr < e;
+                }
+            }
+        }
+        if in_target_block && line.starts_with("VmFlags:") {
+            return Some(
+                line.trim_start_matches("VmFlags:")
+                    .split_whitespace()
+                    .map(str::to_string)
+                    .collect(),
+            );
+        }
+    }
+    None
+}
+
+/// Permission string (`r--p`, `---p`, ...) of the mapping covering `addr`.
+#[cfg(target_os = "linux")]
+fn perms_for(addr: usize) -> Option<String> {
+    let maps = std::fs::read_to_string("/proc/self/maps").ok()?;
+    for line in maps.lines() {
+        let mut fields = line.split_whitespace();
+        let range = fields.next()?;
+        let perms = fields.next()?;
+        if let Some((start, end)) = range.split_once('-') {
+            if let (Ok(s), Ok(e)) = (
+                usize::from_str_radix(start, 16),
+                usize::from_str_radix(end, 16),
+            ) {
+                if s <= addr && addr < e {
+                    return Some(perms.to_string());
+                }
+            }
+        }
+    }
+    None
+}


### PR DESCRIPTION
Follow-up to #35, split out so both stay small. Two commits:

**Tests and benches**
- on linux, read /proc/self/smaps and assert the secret page really carries the kernel's lo/dd/wf flags (mlocked, dump-excluded, wipe-on-fork), and watch /proc/self/maps flip ---p / r--p / rw-p through the guard lifecycle. this catches a silently dropped madvise even when every functional test still passes.
- concurrency stress: 8 threads churning their own secrets, nothing bleeds across pages.
- tests/performance.rs: throughput smoke tests with generous bounds so they only trip on real regressions (a per-read allocation, a leaked page per construction). they print their measurements in test output and skip assertions under qemu.
- criterion benches with plain-Vec baselines, in benches/.

**Readme**
- a Performance section with the measured numbers and what follows from them: construction ~2.8µs (~5 syscalls), guard cycle ~1.1µs (two mprotect), roughly 300x a plain allocation — noise for credentials, wrong for a per-request hot loop. `cargo bench` reproduces the table on any machine.

Merge #35 first; this then shows just these two commits.