### PR TITLE
bump to edition 2024, declare MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "memsafe"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 description = "A Secure cross-platform Rust library for securely wrapping data in memory"
 authors = [
     "shshemi <shshemi@gmail.com>",

--- a/benches/memsafe_bench.rs
+++ b/benches/memsafe_bench.rs
@@ -5,7 +5,7 @@
 //! are the per-operation overhead and how it compares to an unprotected
 //! heap buffer. The `baseline_*` benches exist for that comparison.
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use memsafe::Secret;
 
 fn construction(c: &mut Criterion) {

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -7,9 +7,9 @@ use crate::ffi::mem_noaccess;
 use crate::ffi::{mem_no_dump, mem_wipe_on_fork};
 
 use crate::{
+    MemoryError,
     ffi::{mem_alloc, mem_dealloc, mem_lock, mem_readonly, mem_readwrite, mem_unlock},
     ptr_ops::{ptr_deref, ptr_deref_mut, ptr_drop_in_place, ptr_fill_zero, secure_zero},
-    MemoryError,
 };
 
 // No `Debug`: this crate withholds `Debug` from every type that participates

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -7,7 +7,7 @@ mod unix;
 use libc::{MAP_ANONYMOUS, MAP_PRIVATE, PROT_NONE, PROT_READ, PROT_WRITE};
 
 #[cfg(target_os = "linux")]
-use libc::{c_void, MADV_DONTDUMP};
+use libc::{MADV_DONTDUMP, c_void};
 
 #[cfg(windows)]
 mod win;

--- a/src/ptr_ops.rs
+++ b/src/ptr_ops.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{compiler_fence, Ordering};
+use std::sync::atomic::{Ordering, compiler_fence};
 
 /// Volatile, compiler-fenced zeroization of `*ptr`.
 ///

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,6 +1,6 @@
+use crate::MemoryError;
 use crate::cell::Cell;
 use crate::mem_safe::{MemSafe, MemSafeRead, MemSafeWrite};
-use crate::MemoryError;
 
 /// A fixed-size secret stored entirely *inline* within a protected memory page.
 ///

--- a/src/type_state.rs
+++ b/src/type_state.rs
@@ -21,7 +21,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::{cell::Cell, MemoryError};
+use crate::{MemoryError, cell::Cell};
 
 /// Represents a memory state with no access permissions.
 #[cfg(unix)]

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -32,8 +32,8 @@ impl Drop for SpySource {
 
 #[test]
 fn from_bytes_zeroizes_source_before_drop() {
-    use std::sync::atomic::Ordering;
     use std::sync::Arc;
+    use std::sync::atomic::Ordering;
 
     let flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let source = SpySource {
@@ -66,8 +66,8 @@ fn from_bytes_zeroizes_source_before_drop() {
 
 #[test]
 fn from_bytes_length_error_does_not_zeroize_source() {
-    use std::sync::atomic::Ordering;
     use std::sync::Arc;
+    use std::sync::atomic::Ordering;
 
     let flag = Arc::new(std::sync::atomic::AtomicBool::new(true));
     let source = SpySource {


### PR DESCRIPTION
Moves the crate to the 2024 edition 

- `cargo fix --edition` had nothing to migrate; the diff is the two Cargo.toml lines plus rustfmt's updated import ordering.
- The 2024 edition makes the stricter unsafe hygiene lints (`unsafe_op_in_unsafe_fn` and friends) deny-by-default, so the compiler enforces them on future contributions. Good fit for us.
- `rust-version = "1.85"`

No behavior change.
